### PR TITLE
Fix the case of wrong calculation of steps by modifying the jquery selector

### DIFF
--- a/js/jquery.smartWizard-2.0.js
+++ b/js/jquery.smartWizard-2.0.js
@@ -15,7 +15,7 @@
         return this.each(function(){
                 var obj = $(this);
                 var curStepIdx = options.selected;
-                var steps = $("ul > li > a", obj); // Get all anchors in this array
+                var steps = $("ul > li > a[href^='#step-']", obj); // Get all anchors in this array
                 var contentWidth = 0;
                 var loader,msgBox,elmActionBar,elmStepContainer,btNext,btPrevious,btFinish;
                 


### PR DESCRIPTION
The jquery selector used for getting the steps in the wizard
was changed as the older one (ie. "ul > li > a") matched
anchor tags anywhere inside the wizard container resulting in
wrong calculation of no. of steps. The changed selector filters
only those anchor tags that have the href attr starting with
'#step-'

I haven't committed the minified file, let me know if you want me 
to include that as well. 
