### PR TITLE
Respect the disabled class on the next and previous buttons

### DIFF
--- a/js/jquery.smartWizard-2.0.js
+++ b/js/jquery.smartWizard-2.0.js
@@ -80,10 +80,16 @@
                   contentWidth = elmStepContainer.width();
 
                   $(btNext).click(function() {
+                      if($(this).hasClass('buttonDisabled')){
+                        return false;
+                      }
                       doForwardProgress();
                       return false;
                   }); 
                   $(btPrevious).click(function() {
+                      if($(this).hasClass('buttonDisabled')){
+                        return false;
+                      }
                       doBackwardProgress();
                       return false;
                   }); 


### PR DESCRIPTION
I want to be able to control whether a user is able to use the next and previous buttons based on the state of the buttons.  The easy way to do this is for their button handlers to check for the disabled class and drop out if it's assigned.  This seems like a sensible addition, so I'm submitting it here.  Thanks!
