### PR TITLE
Add option to remove Finish button

### DIFF
--- a/js/jquery.smartWizard-2.0.js
+++ b/js/jquery.smartWizard-2.0.js
@@ -76,7 +76,10 @@
                   elmActionBar.append(loader);
                   obj.append(elmStepContainer);
                   obj.append(elmActionBar); 
-                  elmActionBar.append(btFinish).append(btNext).append(btPrevious); 
+                  if (options.includeFinishButton) {
+                    elmActionBar.append(btFinish);
+                  }
+                  elmActionBar.append(btNext).append(btPrevious); 
                   contentWidth = elmStepContainer.width();
 
                   $(btNext).click(function() {
@@ -321,6 +324,7 @@
           contentURL:null, // content url, Enables Ajax content loading
           contentCache:true, // cache step contents, if false content is fetched always from ajax url
           cycleSteps: false, // cycle step navigation
+          includeFinishButton: true, // whether to show a Finish button
           enableFinishButton: false, // make finish button enabled always
           errorSteps:[],    // Array Steps with errors
           labelNext:'Next',


### PR DESCRIPTION
When the wizard is finished, you might want to present several options of how to move forward which are simply links, not a form post.  The easiest way to do this is to have a "finished" step, which contains as its content the links for your options on moving forward, which might be buttons or regular links, just content in the pane.  In this situation, the Finish button does you no good and you don't want it there.

This commit adds a configuration option (defaulting to show) which simply stops the Finish button from being added to the elements at the bottom.
