### PR TITLE
Substitute span element for label in html examples

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -26,28 +26,28 @@
   		<div id="wizard" class="swMain">
   			<ul>
   				<li><a href="#step-1">
-                <label class="stepNumber">1</label>
+                <span class="stepNumber">1</span>
                 <span class="stepDesc">
                    Step 1<br />
                    <small>Step 1 description</small>
                 </span>
             </a></li>
   				<li><a href="#step-2">
-                <label class="stepNumber">2</label>
+                <span class="stepNumber">2</span>
                 <span class="stepDesc">
                    Step 2<br />
                    <small>Step 2 description</small>
                 </span>
             </a></li>
   				<li><a href="#step-3">
-                <label class="stepNumber">3</label>
+                <span class="stepNumber">3</span>
                 <span class="stepDesc">
                    Step 3<br />
                    <small>Step 3 description</small>
                 </span>                   
              </a></li>
   				<li><a href="#step-4">
-                <label class="stepNumber">4</label>
+                <span class="stepNumber">4</span>
                 <span class="stepDesc">
                    Step 4<br />
                    <small>Step 4 description</small>

--- a/smartwizard2-ajax.htm
+++ b/smartwizard2-ajax.htm
@@ -25,28 +25,28 @@
   		<div id="wizard" class="swMain">
   			<ul>
   				<li><a href="#step-1">
-                <label class="stepNumber">1</label>
+                <span class="stepNumber">1</span>
                 <span class="stepDesc">
                    Step 1<br />
                    <small>Step 1 description</small>
                 </span>
             </a></li>
   				<li><a href="#step-2">
-                <label class="stepNumber">2</label>
+                <span class="stepNumber">2</span>
                 <span class="stepDesc">
                    Step 2<br />
                    <small>Step 2 description</small>
                 </span>
             </a></li>
   				<li><a href="#step-3">
-                <label class="stepNumber">3</label>
+                <span class="stepNumber">3</span>
                 <span class="stepDesc">
                    Step 3<br />
                    <small>Step 3 description</small>
                 </span>                   
              </a></li>
   				<li><a href="#step-4">
-                <label class="stepNumber">4</label>
+                <span class="stepNumber">4</span>
                 <span class="stepDesc">
                    Step 4<br />
                    <small>Step 4 description</small>

--- a/smartwizard2-multiple.htm
+++ b/smartwizard2-multiple.htm
@@ -28,28 +28,28 @@
   		<div id="wizard1" class="swMain">
   			<ul>
   				<li><a href="#step-1">
-                <label class="stepNumber">1</label>
+                <span class="stepNumber">1</span>
                 <span class="stepDesc">
                    Step 1<br />
                    <small>Step 1 description</small>
                 </span>
             </a></li>
   				<li><a href="#step-2">
-                <label class="stepNumber">2</label>
+                <span class="stepNumber">2</span>
                 <span class="stepDesc">
                    Step 2<br />
                    <small>Step 2 description</small>
                 </span>
             </a></li>
   				<li><a href="#step-3">
-                <label class="stepNumber">3</label>
+                <span class="stepNumber">3</span>
                 <span class="stepDesc">
                    Step 3<br />
                    <small>Step 3 description</small>
                 </span>                   
              </a></li>
   				<li><a href="#step-4">
-                <label class="stepNumber">4</label>
+                <span class="stepNumber">4</span>
                 <span class="stepDesc">
                    Step 4<br />
                    <small>Step 4 description</small>
@@ -161,28 +161,28 @@
   		<div id="wizard2" class="swMain">
   			<ul>
   				<li><a href="#step-1">
-                <label class="stepNumber">1</label>
+                <span class="stepNumber">1</span>
                 <span class="stepDesc">
                    Step 1<br />
                    <small>Step 1 description</small>
                 </span>
             </a></li>
   				<li><a href="#step-2">
-                <label class="stepNumber">2</label>
+                <span class="stepNumber">2</span>
                 <span class="stepDesc">
                    Step 2<br />
                    <small>Step 2 description</small>
                 </span>
             </a></li>
   				<li><a href="#step-3">
-                <label class="stepNumber">3</label>
+                <span class="stepNumber">3</span>
                 <span class="stepDesc">
                    Step 3<br />
                    <small>Step 3 description</small>
                 </span>                   
              </a></li>
   				<li><a href="#step-4">
-                <label class="stepNumber">4</label>
+                <span class="stepNumber">4</span>
                 <span class="stepDesc">
                    Step 4<br />
                    <small>Step 4 description</small>

--- a/smartwizard2-validation.php
+++ b/smartwizard2-validation.php
@@ -160,28 +160,28 @@
   		<div id="wizard" class="swMain">
   			<ul>
   				<li><a href="#step-1">
-                <label class="stepNumber">1</label>
+                <span class="stepNumber">1</span>
                 <span class="stepDesc">
                    Account Details<br />
                    <small>Fill your account details</small>
                 </span>
             </a></li>
   				<li><a href="#step-2">
-                <label class="stepNumber">2</label>
+                <span class="stepNumber">2</span>
                 <span class="stepDesc">
                    Profile Details<br />
                    <small>Fill your profile details</small>
                 </span>
             </a></li>
   				<li><a href="#step-3">
-                <label class="stepNumber">3</label>
+                <span class="stepNumber">3</span>
                 <span class="stepDesc">
                    Contact Details<br />
                    <small>Fill your contact details</small>
                 </span>
              </a></li>
   				<li><a href="#step-4">
-                <label class="stepNumber">3</label>
+                <span class="stepNumber">3</span>
                 <span class="stepDesc">
                    Other Details<br />
                    <small>Fill your other details</small>

--- a/smartwizard2-vertical.htm
+++ b/smartwizard2-vertical.htm
@@ -23,28 +23,28 @@
   		<div id="wizard" class="swMain">
   			<ul>
   				<li><a href="#step-1">
-                <label class="stepNumber">1</label>
+                <span class="stepNumber">1</span>
                 <span class="stepDesc">
                    Step 1<br />
                    <small>Step 1 description</small>
                 </span>
             </a></li>
   				<li><a href="#step-2">
-                <label class="stepNumber">2</label>
+                <span class="stepNumber">2</span>
                 <span class="stepDesc">
                    Step 2<br />
                    <small>Step 2 description having some more text</small>
                 </span>
             </a></li>
   				<li><a href="#step-3">
-                <label class="stepNumber">3</label>
+                <span class="stepNumber">3</span>
                 <span class="stepDesc">
                    Step 3<br />
                    <small>Step 3 description</small>
                 </span>                   
              </a></li>
   				<li><a href="#step-4">
-                <label class="stepNumber">4</label>
+                <span class="stepNumber">4</span>
                 <span class="stepDesc">
                    Step 4<br />
                    <small>Step 4 description</small>


### PR DESCRIPTION
As it turns out, label is an illegal html element to have inside an anchor (a).

So my page could validate against the w3c html validator, I substituted a span for the label in the step listing at the start of the wizard's html.  That's fine because none of the css or js depend on that element being a label, it just needs to carry the Stepnumber class and a span will do that as well as a label would (but better since it validates).

That's all that's in this commit.
